### PR TITLE
Feature/question2

### DIFF
--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -5,8 +5,8 @@ class Question2Cell: UITableViewCell {
     @IBOutlet weak var label: UILabel!
     @IBOutlet weak var areaImageView: UIImageView!
     
-    public func displayCell(text: String, url: URL) {
-        label.text = text
+    public func setArea(_ name: String, withImageURL url: URL) {
+        label.text = name
         Nuke.loadImage(with: url, into: areaImageView)
     }
 }

--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -5,7 +5,7 @@ class Question2Cell: UITableViewCell {
     @IBOutlet weak var label: UILabel!
     @IBOutlet weak var areaImageView: UIImageView!
     
-    public func cellDisplay(text: String, url: URL) {
+    public func displayCell(text: String, url: URL) {
         self.label.text = text
         Nuke.loadImage(with: url, into: areaImageView)
     }

--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -6,7 +6,7 @@ class Question2Cell: UITableViewCell {
     @IBOutlet weak var areaImageView: UIImageView!
     
     public func displayCell(text: String, url: URL) {
-        self.label.text = text
+        label.text = text
         Nuke.loadImage(with: url, into: areaImageView)
     }
 }

--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -1,6 +1,12 @@
+import Nuke
 import UIKit
 
 class Question2Cell: UITableViewCell {
     @IBOutlet weak var label: UILabel!
     @IBOutlet weak var areaImageView: UIImageView!
+    
+    func cellDisplay(label: String, url: URL) {
+        self.label?.text = label
+        Nuke.loadImage(with: url, into: areaImageView)
+    }
 }

--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -5,8 +5,8 @@ class Question2Cell: UITableViewCell {
     @IBOutlet weak var label: UILabel!
     @IBOutlet weak var areaImageView: UIImageView!
     
-    func cellDisplay(label: String, url: URL) {
-        self.label?.text = label
+   public func cellDisplay(text: String, url: URL) {
+        self.label.text = text
         Nuke.loadImage(with: url, into: areaImageView)
     }
 }

--- a/intern_2week_study/Question/Question2/Question2Cell.swift
+++ b/intern_2week_study/Question/Question2/Question2Cell.swift
@@ -5,7 +5,7 @@ class Question2Cell: UITableViewCell {
     @IBOutlet weak var label: UILabel!
     @IBOutlet weak var areaImageView: UIImageView!
     
-   public func cellDisplay(text: String, url: URL) {
+    public func cellDisplay(text: String, url: URL) {
         self.label.text = text
         Nuke.loadImage(with: url, into: areaImageView)
     }

--- a/intern_2week_study/Question/Question2/Question2Cell.xib
+++ b/intern_2week_study/Question/Question2/Question2Cell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" restorationIdentifier="SampleArticleListCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="question2Cell" id="KGk-i7-Jjw" customClass="Question2Cell" customModule="intern_2week_study" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" restorationIdentifier="SampleArticleListCell" selectionStyle="default" indentationWidth="10" reuseIdentifier="Question2Cell" id="KGk-i7-Jjw" customClass="Question2Cell" customModule="intern_2week_study" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -19,10 +19,8 @@ final class Question2ViewController: UIViewController {
     // 画面が読み込まれたときに行う処理
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.frame = view.bounds
         tableView.dataSource = self
         tableView.register(UINib(nibName: "Question2Cell", bundle: nil), forCellReuseIdentifier: "Question2Cell")
-        view.addSubview(tableView)
     }
 }
 
@@ -34,13 +32,13 @@ extension Question2ViewController: UITableViewDataSource {
     
     // セルをカスタマイズ
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell {
-            let url = URL(string: images[indexPath.row])!
-            cell.cellDisplay(label: areaTexts[indexPath.row], url: url)
-            
-            return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell else {
+            return UITableViewCell()
         }
-        return UITableViewCell()
+        let url = URL(string: images[indexPath.row])!
+        cell.cellDisplay(label: areaTexts[indexPath.row], url: url)
+        
+        return cell
     }
 }
 

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -19,7 +19,7 @@ final class Question2ViewController: UIViewController {
     // 画面が読み込まれたときに行う処理
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.register(UINib(nibName: "Question2Cell", bundle: nil), forCellReuseIdentifier: "Question2Cell")
+        tableView.register(R.nib.question2Cell)
     }
 }
 
@@ -31,12 +31,9 @@ extension Question2ViewController: UITableViewDataSource {
     
     // セルをカスタマイズ
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard
-            let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell,
-            let url = URL(string: images[indexPath.row]) else {
-                return UITableViewCell()
-        }
-        cell.displayCell(text: areaTexts[indexPath.row], url: url)
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell, let url = URL(string: images[indexPath.row]), let areaText = areaTexts[safe: indexPath.row]
+            else { return UITableViewCell() }
+        cell.setArea(areaText, withImageURL: url)
         return cell
     }
 }
@@ -45,7 +42,7 @@ extension Question2ViewController: UITableViewDelegate {
     // セルを押したときにアラートを表示
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let alertController = UIAlertController(title: areaTexts[indexPath.row], message: "メッセージ", preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
         present(alertController, animated: true)
     }
 }

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -31,8 +31,10 @@ extension Question2ViewController: UITableViewDataSource {
     
     // セルをカスタマイズ
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell, let url = URL(string: images[indexPath.row]) else {
-            return UITableViewCell()
+        guard
+            let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell,
+            let url = URL(string: images[indexPath.row]) else {
+                return UITableViewCell()
         }
         cell.displayCell(text: areaTexts[indexPath.row], url: url)
         return cell

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -36,7 +36,7 @@ extension Question2ViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         let url = URL(string: images[indexPath.row])!
-        cell.cellDisplay(text: areaTexts[indexPath.row], url: url)
+        cell.displayCell(text: areaTexts[indexPath.row], url: url)
         return cell
     }
 }
@@ -44,8 +44,7 @@ extension Question2ViewController: UITableViewDataSource {
 extension Question2ViewController: UITableViewDelegate {
     // セルを押したときにアラートを表示
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        var alertController = UIAlertController()
-        alertController = UIAlertController(title: areaTexts[indexPath.row], message: "メッセージ", preferredStyle: .alert)
+        let alertController = UIAlertController(title: areaTexts[indexPath.row], message: "メッセージ", preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         present(alertController, animated: true)
     }

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -6,19 +6,50 @@ final class Question2ViewController: UIViewController {
     
     private let areaTexts: [String] = ["茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県"]
     
+    private let images: [String] = [
+        "https://2.bp.blogspot.com/-c-Ws8qkxBq4/XKF92e4mmBI/AAAAAAABSHQ/YHiJQq1xOQwpQFXKHhrvZmPa4EhW6xCUQCLcBGAs/s450/gengou_happyou_reiwa.png",
+        "https://1.bp.blogspot.com/-3nzUHu2AP3c/Xx-0ffvXGJI/AAAAAAABaWU/WjGBzNs82ZUIqCT-EmLxtopmazY3Z6ecACNcBGAsYHQ/s400/mask_karamaru_megane_earphone.png",
+        "https://1.bp.blogspot.com/-ZOg0qAG4ewU/Xub_uw6q0DI/AAAAAAABZio/MshyuVBpHUgaOKJtL47LmVkCf5Vge6MQQCNcBGAsYHQ/s400/pose_pien_uruuru_woman.png",
+        "https://1.bp.blogspot.com/-nFOSMkMAO3E/XyZ_YN6Z_yI/AAAAAAABabc/JseXD6VqjQ8MD1n0Osmi2DA3cmUq99nlgCNcBGAsYHQ/s450/movie_baiyousou.png",
+        "https://1.bp.blogspot.com/-R9dY32HIJE0/XyI9dfqT0FI/AAAAAAABaYg/XZEM_lCzSikkmpBCJWmUZJC0JpOSPMhwACNcBGAsYHQ/s450/shopping_bag_temochi_man.png",
+        "https://1.bp.blogspot.com/-VxmdFd29LXE/XwkxkUU8lrI/AAAAAAABaCk/_wKalHgyMzQ8yZgyVnNTw2ni_7Cg8jbwQCNcBGAsYHQ/s400/okinawa_shishimai.png",
+        "https://1.bp.blogspot.com/-RSuvrQ4wbQY/Xv3UKX1cg6I/AAAAAAABZ0w/wNiipvjzqxEHOZBapWy9VbYCDUOtFcNHwCNcBGAsYHQ/s450/rtif_gate_scanner_figure.png"
+    ]
+    
+    // 画面が読み込まれたときに行う処理
     override func viewDidLoad() {
         super.viewDidLoad()
+        tableView.frame = view.bounds
+        tableView.dataSource = self
+        tableView.register(UINib(nibName: "Question2Cell", bundle: nil), forCellReuseIdentifier: "Question2Cell")
+        view.addSubview(tableView)
     }
 }
 
 extension Question2ViewController: UITableViewDataSource {
+    // 配列の要素数分セルを表示
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // TableViewに表示する行数を指定する
-        return 0
+        return areaTexts.count
     }
     
+    // セルをカスタマイズ
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // 仮のセル
+        if let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell {
+            let url = URL(string: images[indexPath.row])!
+            cell.cellDisplay(label: areaTexts[indexPath.row], url: url)
+            
+            return cell
+        }
         return UITableViewCell()
+    }
+}
+
+extension Question2ViewController: UITableViewDelegate {
+    // セルを押したときにアラートを表示
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        var alertController = UIAlertController()
+        alertController = UIAlertController(title: areaTexts[indexPath.row], message: "メッセージ", preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        present(alertController, animated: true)
     }
 }

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -36,8 +36,7 @@ extension Question2ViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         let url = URL(string: images[indexPath.row])!
-        cell.cellDisplay(label: areaTexts[indexPath.row], url: url)
-        
+        cell.cellDisplay(text: areaTexts[indexPath.row], url: url)
         return cell
     }
 }

--- a/intern_2week_study/Question/Question2/Question2ViewController.swift
+++ b/intern_2week_study/Question/Question2/Question2ViewController.swift
@@ -19,7 +19,6 @@ final class Question2ViewController: UIViewController {
     // 画面が読み込まれたときに行う処理
     override func viewDidLoad() {
         super.viewDidLoad()
-        tableView.dataSource = self
         tableView.register(UINib(nibName: "Question2Cell", bundle: nil), forCellReuseIdentifier: "Question2Cell")
     }
 }
@@ -32,10 +31,9 @@ extension Question2ViewController: UITableViewDataSource {
     
     // セルをカスタマイズ
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "Question2Cell") as? Question2Cell, let url = URL(string: images[indexPath.row]) else {
             return UITableViewCell()
         }
-        let url = URL(string: images[indexPath.row])!
         cell.displayCell(text: areaTexts[indexPath.row], url: url)
         return cell
     }


### PR DESCRIPTION
## 課題

[課題2](https://github.com/Caraquri/intern_2week_study_ios/issues/2)

## 概要
1. areaTextsの内容をcellのlabelに表示
2. Nukeというライブラリを用いて、cellのImageViewに画像を表示
3. cellをタップした際にUIAlertControllerを用いてアラートを表示する処理を実装
- titleはcellに表示している文字列を使用
- messageは自由に設定
- アクションは”OK”を表示

## 特に確認して頂きたい項目

- カスタムセルの使い方

## 動作確認用

<img src="https://user-images.githubusercontent.com/50396652/90045812-8e98a000-dd0a-11ea-9428-2bf00df0dea8.gif" width="300" />

## 参考URL
- [UITableViewの使い方 【Swift4.2 , Xcode10】](https://qiita.com/abouch/items/3617ce37c4dd86932365)
- [SwiftのTableViewCellを使ってTableViewを自由にカスタマイズ](https://qiita.com/Ajyarimochi/items/0154030bde239d703806)
- [【iOS】TableViewのカスタムセルを作る方法2つを比べてみた（PrototypeCell / xibファイル）](https://qiita.com/orimomo/items/e12a0e468f083bcb7a50)
- [[Swift]カスタムセルを用いて、UserDefaultsの中にあるものを表示する](https://qiita.com/saffron_furafoop/items/33425f054d37b8fb1fd4)
- [【Swift 初心者】[超簡単] UITableViewのセルをタップした時のアクション](https://tech.playground.style/swift/tableview-didselectroeat-beginner-alert/)
- [Protocols](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID277)
- [Nuke](https://github.com/kean/Nuke)